### PR TITLE
[ADD] add specific python dependencies version to avoid problems in runbot and another environments running the forecast modules with non updated dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pandas
-numexpr
+pandas==0.16.2
+numexpr==2.4.4


### PR DESCRIPTION
This change is needed to properly run the runbot instances for the forecast module. This was discover in #36 issue.

Best Regards