### PR TITLE
[ADD] Add a way to automatically create the forecast rule filter from the stock demand wizard.

### DIFF
--- a/stock_forecast/README.rst
+++ b/stock_forecast/README.rst
@@ -61,36 +61,46 @@ To use this module, you need to:
 
 **Demand Forecast**
 
-A demand forecast is set by the way that the forecast rule is configured.  For
-a demand forecast rule you need to define the next elements:
+A demand forecast is set by the way that the forecast rule is configured. This
+kind of rule need to the linked to a filter that have at least next elements
+at domain:
 
 - A product, group of products or product category.
 - A range of dates where the data will be extract.
 - A location you want to review.
-- Optionally use a group_by key in filter context to group the data by a
-  date/datetime. You can use the syntax ``'group_by': [datefield:period]``.
-- Use a forecast_step to indicate that you want to fill the empty demand dates
-  with 0.0 values.
 
-The period refer by group_by and the forecast_step can be one of the next
-options: ``['day', 'week', 'month', 'year']``
 
-The Demand Forecast are generated using forecast rules related to the
-``stock.history`` type. This module holds the information about the product
-demand. To calculate the product demand you can go to:
+Also the filter need to have the context required forecast keys
+``['forecast_order', 'forecast_value']``. Optionally can use the
+``forecast_step`` key in the filter context to indicate that you want to fill
+the empty demand dates with 0.0 values and a ``group_by`` key to group the
+data by a date/datetime. You can use the syntax ``'group_by':
+[datefield:period]``.  The ``period`` and the ``forecast_step`` can
+be one of the next options: ``['day', 'week', 'month', 'year']``
 
-- ``Reporting > Warehouse > Stock Demand`` wizard and generate the demand for
-  a specific product / location.  If you use the **Stock Demand** wizard you
-  will found at the search bar the pre-defined filters of you search so you
-  can this sum of filters into one and re-used in your forecast rule.
-- ``Reporting > Warehouse > Stock Valuation`` wizard and generate the demand
-  for all the products / locations in your system. **WARNING: This could take
-  a lot of time if you have a database with a lot of products and movements.
-  We highly recommend to generate the demand you need using the ``Stock
-  Demand`` wizard**.
+**NOTE: For more information about how does the forecasting rules works you
+can find out at Forecasting Rules module description**
 
-Also, If you install this module using data demo you can find examples of some
-demand forecast rules that you can copy and reuse for your purpose.
+The Demand Forecast Rule is related to the ``stock.history`` model. This last
+one holds the information about the product demand. To calculate the product
+demand you can go to ``Reporting > Warehouse > Stock Demand`` wizard and
+generate a query of the demand for a specific product / location. In the
+``Stock Demand`` wizard there is an option (a check field) that let you
+auto-generate a filter ready to be use in a forecast rule. The generate filter
+will have this name by default ``Stock Demand for {product} in {location}
+(From {date_from} to {date_to}``
+
+*NOTE*: You can run the - ``Reporting > Warehouse > Stock Valuation`` wizard
+and generate the demand for all the products / locations in your system.
+**WARNING: This could take a lot of time if you have a database with a lot of
+products and movements. We highly recommend to generate the demand you need
+using the Stock Demand wizard**.
+
+**Forecast Rules Examples**
+
+If you install this module using data demo you can find examples of some
+demand forecast rules at ``Settings > Technical Features > Forecasting >
+Forecasting Rules`` menu that you can copy and reuse for your purpose.
 
 - You can extract a demand for a product. All the operations for a range of
   date. Check ``(SFD01) 2015 Demand for iMac Product in WH/Stoc``.
@@ -133,8 +143,6 @@ TODO
   module.
 - Update picking/move data to be generated only for the current year of the
   installation of the module. Right now is generated for the 2015 year.
-- When generating the ir.filter by the stock.demand wizard the range of dates
-  are not taking into account.
 
 Credits
 =======

--- a/stock_forecast/i18n/es.po
+++ b/stock_forecast/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-10-14 19:44+0000\n"
-"PO-Revision-Date: 2015-10-14 19:44+0000\n"
+"POT-Creation-Date: 2015-10-19 23:47+0000\n"
+"PO-Revision-Date: 2015-10-19 23:47+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -81,24 +81,35 @@ msgid "Date End used to get the range of the demands"
 msgstr "Fecha Final del rango utilizada para obtener la demanda"
 
 #. module: stock_forecast
+#: view:stock.history:stock_forecast.view_stock_demand_history_search
 #: field:wizard.stock.demand,date_from:0
 msgid "Date From"
-msgstr "Date From"
+msgstr "Desde la Fecha"
 
 #. module: stock_forecast
 #: help:wizard.stock.demand,date_from:0
 msgid "Date Start used to get the range of the demands"
-msgstr "Date Start used to get the range of the demands"
+msgstr "Fecha inicio usada para dar el rango de la demanda"
+
+#. module: stock_forecast
+#: view:stock.history:stock_forecast.view_stock_demand_history_search
+msgid "Date To"
+msgstr "Hasta la Fecha"
 
 #. module: stock_forecast
 #: field:wizard.stock.demand,date_to:0
 msgid "Date to"
-msgstr "Date to"
+msgstr "Hasta la Fecha"
+
+#. module: stock_forecast
+#: view:stock.history:stock_forecast.view_stock_demand_history_search
+msgid "Demand Lines"
+msgstr "Lineas de Demanda"
 
 #. module: stock_forecast
 #: help:wizard.stock.demand,location_id:0
 msgid "Destination location of the moves to show"
-msgstr "Destination location of the moves to show"
+msgstr "Ubicación destiono de los movimientos a mostrar"
 
 #. module: stock_forecast
 #: view:forecast:stock_forecast.stock_forecast_view_form
@@ -123,9 +134,25 @@ msgid "Forecasts"
 msgstr "Pronósticos"
 
 #. module: stock_forecast
+#: code:addons/stock_forecast/wizard/stock_demand.py:77
+#, python-format
+msgid "From"
+msgstr "Desde"
+
+#. module: stock_forecast
+#: field:wizard.stock.demand,demand_filter:0
+msgid "Generate Rule Filter"
+msgstr "Generar Filtro de la Regla"
+
+#. module: stock_forecast
 #: field:wizard.stock.demand,id:0
 msgid "ID"
 msgstr "ID"
+
+#. module: stock_forecast
+#: help:wizard.stock.demand,demand_filter:0
+msgid "If True generate a Search Filter to re-use in the forecast rule. If False only check the demand"
+msgstr "Si es verdadero genera un filtro de busqueda a re-usar en la regla de pronóstico. Si es falso solo mostrará el resultado de la búsqueda"
 
 #. module: stock_forecast
 #: field:wizard.stock.demand,write_uid:0
@@ -143,9 +170,11 @@ msgid "Location"
 msgstr "Ubicación"
 
 #. module: stock_forecast
+#: code:addons/stock_forecast/wizard/stock_demand.py:75
 #: view:forecast:stock_forecast.forecast_search_view
 #: field:forecast,product_id:0
 #: field:wizard.stock.demand,product_id:0
+#, python-format
 msgid "Product"
 msgstr "Producto"
 
@@ -182,10 +211,10 @@ msgid "Stock Demand At Date"
 msgstr "Demanda a la fecha"
 
 #. module: stock_forecast
-#: code:addons/stock_forecast/wizard/stock_demand.py:54
+#: code:addons/stock_forecast/wizard/stock_demand.py:75
 #, python-format
-msgid "Stock Demands At Date"
-msgstr "Demanda a la fecha"
+msgid "Stock Demand for"
+msgstr "Demanda de Inventario para"
 
 #. module: stock_forecast
 #: view:stock.history:stock_forecast.view_stock_demand_history_report_tree
@@ -198,6 +227,12 @@ msgid "from"
 msgstr "desde"
 
 #. module: stock_forecast
+#: code:addons/stock_forecast/wizard/stock_demand.py:76
+#, python-format
+msgid "in"
+msgstr "en"
+
+#. module: stock_forecast
 #: view:wizard.stock.demand:stock_forecast.view_wizard_demand_history
 msgid "or"
 msgstr "o"
@@ -206,4 +241,10 @@ msgstr "o"
 #: view:forecast:stock_forecast.stock_forecast_view_form
 msgid "template"
 msgstr "plantilla"
+
+#. module: stock_forecast
+#: code:addons/stock_forecast/wizard/stock_demand.py:77
+#, python-format
+msgid "to"
+msgstr "a"
 

--- a/stock_forecast/i18n/stock_forecast.pot
+++ b/stock_forecast/i18n/stock_forecast.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-10-14 19:28+0000\n"
-"PO-Revision-Date: 2015-10-14 19:28+0000\n"
+"POT-Creation-Date: 2015-10-19 23:47+0000\n"
+"PO-Revision-Date: 2015-10-19 23:47+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -81,6 +81,7 @@ msgid "Date End used to get the range of the demands"
 msgstr ""
 
 #. module: stock_forecast
+#: view:stock.history:stock_forecast.view_stock_demand_history_search
 #: field:wizard.stock.demand,date_from:0
 msgid "Date From"
 msgstr ""
@@ -91,8 +92,18 @@ msgid "Date Start used to get the range of the demands"
 msgstr ""
 
 #. module: stock_forecast
+#: view:stock.history:stock_forecast.view_stock_demand_history_search
+msgid "Date To"
+msgstr ""
+
+#. module: stock_forecast
 #: field:wizard.stock.demand,date_to:0
 msgid "Date to"
+msgstr ""
+
+#. module: stock_forecast
+#: view:stock.history:stock_forecast.view_stock_demand_history_search
+msgid "Demand Lines"
 msgstr ""
 
 #. module: stock_forecast
@@ -123,8 +134,24 @@ msgid "Forecasts"
 msgstr ""
 
 #. module: stock_forecast
+#: code:addons/stock_forecast/wizard/stock_demand.py:77
+#, python-format
+msgid "From"
+msgstr ""
+
+#. module: stock_forecast
+#: field:wizard.stock.demand,demand_filter:0
+msgid "Generate Rule Filter"
+msgstr ""
+
+#. module: stock_forecast
 #: field:wizard.stock.demand,id:0
 msgid "ID"
+msgstr ""
+
+#. module: stock_forecast
+#: help:wizard.stock.demand,demand_filter:0
+msgid "If True generate a Search Filter to re-use in the forecast rule. If False only check the demand"
 msgstr ""
 
 #. module: stock_forecast
@@ -143,9 +170,11 @@ msgid "Location"
 msgstr ""
 
 #. module: stock_forecast
+#: code:addons/stock_forecast/wizard/stock_demand.py:75
 #: view:forecast:stock_forecast.forecast_search_view
 #: field:forecast,product_id:0
 #: field:wizard.stock.demand,product_id:0
+#, python-format
 msgid "Product"
 msgstr ""
 
@@ -182,9 +211,9 @@ msgid "Stock Demand At Date"
 msgstr ""
 
 #. module: stock_forecast
-#: code:addons/stock_forecast/wizard/stock_demand.py:54
+#: code:addons/stock_forecast/wizard/stock_demand.py:75
 #, python-format
-msgid "Stock Demands At Date"
+msgid "Stock Demand for"
 msgstr ""
 
 #. module: stock_forecast
@@ -198,6 +227,12 @@ msgid "from"
 msgstr ""
 
 #. module: stock_forecast
+#: code:addons/stock_forecast/wizard/stock_demand.py:76
+#, python-format
+msgid "in"
+msgstr ""
+
+#. module: stock_forecast
 #: view:wizard.stock.demand:stock_forecast.view_wizard_demand_history
 msgid "or"
 msgstr ""
@@ -205,5 +240,11 @@ msgstr ""
 #. module: stock_forecast
 #: view:forecast:stock_forecast.stock_forecast_view_form
 msgid "template"
+msgstr ""
+
+#. module: stock_forecast
+#: code:addons/stock_forecast/wizard/stock_demand.py:77
+#, python-format
+msgid "to"
 msgstr ""
 

--- a/stock_forecast/static/description/index.html
+++ b/stock_forecast/static/description/index.html
@@ -152,8 +152,9 @@ product in the section
      </strong>
     </p>
     <p class="oe_mt32">
-     A demand forecast is set by the way that the forecast rule is configured.  For
-a demand forecast rule you need to define the next elements:
+     A demand forecast is set by the way that the forecast rule is configured. This
+kind of rule need to the linked to a filter that have at least next elements
+at domain:
     </p>
     <ul class="simple">
      <li>
@@ -165,66 +166,101 @@ a demand forecast rule you need to define the next elements:
      <li>
       A location you want to review.
      </li>
-     <li>
-      Optionally use a group_by key in filter context to group the data by a
-date/datetime. You can use the syntax
-      <code class="docutils literal">
-       'group_by': [datefield:period]
-      </code>
-      .
-     </li>
-     <li>
-      Use a forecast_step to indicate that you want to fill the empty demand dates
-with 0.0 values.
-     </li>
     </ul>
     <p class="oe_mt32">
-     The period refer by group_by and the forecast_step can be one of the next
-options:
+     Also the filter need to have the context required forecast keys
+     <code class="docutils literal">
+      ['forecast_order', 'forecast_value']
+     </code>
+     . Optionally can use the
+     <code class="docutils literal">
+      forecast_step
+     </code>
+     key in the filter context to indicate that you want to fill
+the empty demand dates with 0.0 values and a
+     <code class="docutils literal">
+      group_by
+     </code>
+     key to group the
+data by a date/datetime. You can use the syntax
+     <code class="docutils literal">
+      'group_by':
+[datefield:period]
+     </code>
+     .  The
+     <code class="docutils literal">
+      period
+     </code>
+     and the
+     <code class="docutils literal">
+      forecast_step
+     </code>
+     can
+be one of the next options:
      <code class="docutils literal">
       ['day', 'week', 'month', 'year']
      </code>
     </p>
     <p class="oe_mt32">
-     The Demand Forecast are generated using forecast rules related to the
+     <strong>
+      NOTE: For more information about how does the forecasting rules works you
+can find out at Forecasting Rules module description
+     </strong>
+    </p>
+    <p class="oe_mt32">
+     The Demand Forecast Rule is related to the
      <code class="docutils literal">
       stock.history
      </code>
-     type. This module holds the information about the product
-demand. To calculate the product demand you can go to:
+     model. This last
+one holds the information about the product demand. To calculate the product
+demand you can go to
+     <code class="docutils literal">
+      Reporting &gt; Warehouse &gt; Stock Demand
+     </code>
+     wizard and
+generate a query of the demand for a specific product / location. In the
+     <code class="docutils literal">
+      Stock Demand
+     </code>
+     wizard there is an option (a check field) that let you
+auto-generate a filter ready to be use in a forecast rule. The generate filter
+will have this name by default
+     <code class="docutils literal">
+      Stock Demand for {product} in {location}
+(From {date_from} to {date_to}
+     </code>
     </p>
-    <ul class="simple">
-     <li>
-      <code class="docutils literal">
-       Reporting &gt; Warehouse &gt; Stock Demand
-      </code>
-      wizard and generate the demand for
-a specific product / location.  If you use the
-      <strong>
-       Stock Demand
-      </strong>
-      wizard you
-will found at the search bar the pre-defined filters of you search so you
-can this sum of filters into one and re-used in your forecast rule.
-     </li>
-     <li>
-      <code class="docutils literal">
-       Reporting &gt; Warehouse &gt; Stock Valuation
-      </code>
-      wizard and generate the demand
-for all the products / locations in your system.
-      <strong>
-       WARNING: This could take
-a lot of time if you have a database with a lot of products and movements.
-We highly recommend to generate the demand you need using the ``Stock
-Demand`` wizard
-      </strong>
-      .
-     </li>
-    </ul>
     <p class="oe_mt32">
-     Also, If you install this module using data demo you can find examples of some
-demand forecast rules that you can copy and reuse for your purpose.
+     <em>
+      NOTE
+     </em>
+     : You can run the -
+     <code class="docutils literal">
+      Reporting &gt; Warehouse &gt; Stock Valuation
+     </code>
+     wizard
+and generate the demand for all the products / locations in your system.
+     <strong>
+      WARNING: This could take a lot of time if you have a database with a lot of
+products and movements. We highly recommend to generate the demand you need
+using the Stock Demand wizard
+     </strong>
+     .
+    </p>
+    <p class="oe_mt32">
+     <strong>
+      Forecast Rules Examples
+     </strong>
+    </p>
+    <p class="oe_mt32">
+     If you install this module using data demo you can find examples of some
+demand forecast rules at
+     <code class="docutils literal">
+      Settings &gt; Technical Features &gt; Forecasting &gt;
+Forecasting Rules
+     </code>
+     menu that you can copy and reuse for your purpose.
     </p>
     <ul class="simple">
      <li>
@@ -322,10 +358,6 @@ module.
      <li>
       Update picking/move data to be generated only for the current year of the
 installation of the module. Right now is generated for the 2015 year.
-     </li>
-     <li>
-      When generating the ir.filter by the stock.demand wizard the range of dates
-are not taking into account.
      </li>
     </ul>
    </div>

--- a/stock_forecast/tests/test_stock_demand.py
+++ b/stock_forecast/tests/test_stock_demand.py
@@ -10,6 +10,8 @@
 ############################################################################
 
 from openerp.tests import common
+from openerp import fields
+from dateutil.relativedelta import relativedelta
 
 
 class TestForecastDemand(common.TransactionCase):
@@ -23,6 +25,35 @@ class TestForecastDemand(common.TransactionCase):
         self.demand_obj = self.env['wizard.stock.demand']
         self.move_obj = self.env['stock.move']
 
+    def create_and_run_demand_wizard(self, create_filter):
+        """
+        - Create a stock demand wizard with random product and location
+        - Run demand wizard to activate the stock.history
+        - If create_filter True/False indicate if create forecast rule filter
+        - Search for the filter created.
+
+        :return: result of search the forecasr rule filter
+        """
+        product = self.env['product.product'].search([])[0]
+        location = self.env['stock.location'].search([])[0]
+        wiz = self.demand_obj.create({
+            'product_id': product.id,
+            'location_id': location.id,
+            'date_from': (fields.date.today() - relativedelta(
+                months=1)).strftime('%Y-%m-%d'),
+            'date_to': fields.date.today(),
+            'demand_filter': create_filter,
+        })
+        self.assertTrue(wiz)
+        wiz.open_table()
+        name, domain, model = wiz.get_demand_data()
+        irfilter = self.env['ir.filters'].search([
+            ('name', '=', name),
+            ('domain', '=', str(domain)),
+            ('model_id', '=', model),
+        ])
+        return irfilter
+
     def test_01(self):
         """Return the action from the wizard
         """
@@ -32,7 +63,7 @@ class TestForecastDemand(common.TransactionCase):
             demand_brw = self.demand_obj.create({
                 'product_id': move_brw.product_id.id,
                 'location_id': move_brw.location_id.id,
-                'date_from': '2015-01-01 00:00:00',
+                'date_from': '2015-01-01',
                 'date_to': move_brw.create_date,
             })
             action = demand_brw.open_table()
@@ -42,8 +73,10 @@ class TestForecastDemand(common.TransactionCase):
             for values in domain:
                 # Validating the values in the domain
                 if 'date' in values[0]:
-                    self.assertTrue(values[2] == move_brw.create_date or
-                                    values[2] == '2015-01-01 00:00:00')
+                    domain_date = values[2]
+                    move_date = fields.Datetime.from_string(
+                        move_brw.create_date).strftime('%Y-%m-%d')
+                    self.assertTrue(domain_date in [move_date, '2015-01-01'])
                 elif 'product' in values[0]:
                     self.assertEqual(values[2], move_brw.product_id.id)
                 elif 'product' in values[0]:
@@ -56,3 +89,15 @@ class TestForecastDemand(common.TransactionCase):
         if history_brw:
             # Validating the new compute field was computed
             self.assertTrue(history_brw.quantity_onstock >= 0)
+
+    def test_03(self):
+        """ Stock Demand: Auto Generate Forecast Rule Filter
+        """
+        irfilter = self.create_and_run_demand_wizard(create_filter=True)
+        self.assertTrue(irfilter)
+
+    def test_04(self):
+        """ Stock Demand: Do not Generate Forecast Rule Filter
+        """
+        irfilter = self.create_and_run_demand_wizard(create_filter=False)
+        self.assertFalse(irfilter)

--- a/stock_forecast/wizard/stock_demand.py
+++ b/stock_forecast/wizard/stock_demand.py
@@ -21,16 +21,20 @@ class StockDemand(models.TransientModel):
                                  'the information to show, '
                                  'We will show you only moves '
                                  'related to this product')
-    date_from = fields.Datetime('Date From',
-                                help='Date Start used to get '
-                                'the range of the demands')
-    date_to = fields.Datetime('Date to',
-                              help='Date End used to get '
-                              'the range of the demands')
+    date_from = fields.Date('Date From',
+                            help='Date Start used to get '
+                            'the range of the demands')
+    date_to = fields.Date('Date to',
+                          help='Date End used to get '
+                          'the range of the demands')
     location_id = fields.Many2one('stock.location',
                                   'Location',
                                   help='Destination location '
                                   'of the moves to show')
+    demand_filter = fields.Boolean(
+        'Generate Rule Filter',
+        help='If True generate a Search Filter to re-use in the forecast rule'
+             '. If False only check the demand')
 
     @api.multi
     def open_table(self):
@@ -38,27 +42,75 @@ class StockDemand(models.TransientModel):
         Open the stock history view using the info registered in the wizard
         '''
         ctx = dict(self._context).copy()
-        ctx['history_date'] = self.date_to
-        ctx['search_default_product_id'] = self.product_id.id
-        ctx['search_default_location_id'] = self.location_id.id
-        ctx['forecast_value'] = 'quantity'
-        ctx['forecast_order'] = 'date'
+        ctx.update({
+            'history_date': self.date_to,
+        })
+        name, domain, model = self.get_demand_data()
+
+        if self.demand_filter:
+            self.create_demand_filter(name, domain, model)
+
         tree_view = self.env.ref('stock_forecast.'
                                  'view_stock_demand_history_report_tree')
         return {
-            'domain': [('date', '>=', self.date_from),
-                       ('date', '<=', self.date_to),
-                       ('quantity', '<', 0.0),
-                       ('product_id', '=', self.product_id.id),
-                       ('location_id', '=', self.location_id.id)],
-            'name': _('Stock Demands At Date'),
+            'domain': domain,
+            'name': name,
             'view_type': 'form',
             'views': [(tree_view.id, 'tree')],
             'view_mode': 'tree,graph',
-            'res_model': 'stock.history',
+            'res_model': model,
             'type': 'ir.actions.act_window',
             'context': ctx,
         }
+
+    @api.multi
+    def get_demand_data(self):
+        """
+        Pre-process the date to be use to filter the stock.history records.
+
+        :return: tuple (name view, domain, model name)
+        """
+        model = 'stock.history'
+        name = ' '.join([
+            _('Stock Demand for'), self.product_id.name, _('Product'),
+            _('in'), self.location_id.display_name,
+            '(' + _('From'), self.date_from, _('to'), self.date_to + ')'])
+        domain = [
+            ('date', '>=', self.date_from),
+            ('date', '<=', self.date_to),
+            ('quantity', '<', 0.0),
+            ('product_id', '=', self.product_id.id),
+            ('location_id', '=', self.location_id.id)]
+
+        return name, domain, model
+
+    @api.multi
+    def create_demand_filter(self, name, domain, model):
+        """ Create forecast rule filter
+
+        :name: name of the filter
+        :domain: stock demand domain
+        :model: model name
+
+        :return: if_filters record created
+        """
+        context = {
+            'forecast_value': 'quantity_force_positive',
+            'forecast_order': 'date'}
+        filter_obj = self.env['ir.filters']
+        irfilter = filter_obj.search([
+            ('name', '=', name),
+            ('domain', '=', str(domain)),
+            ('context', '=', str(context)),
+            ('model_id', '=', model),
+        ])
+        if not irfilter:
+            irfilter = filter_obj.create({
+                'name': name,
+                'domain': domain,
+                'context': context,
+                'model_id': model})
+        return irfilter
 
 
 class StockHistory(models.Model):

--- a/stock_forecast/wizard/stock_demand_view.xml
+++ b/stock_forecast/wizard/stock_demand_view.xml
@@ -12,6 +12,7 @@
                         <field name="location_id" required='1'/>
                         <field name="date_from" required='1'/>
                         <field name="date_to" required='1'/>
+                        <field name="demand_filter"/>
                     </group>
                     <footer>
                         <button name="open_table" string="Retrieve the Inventory Value" type="object"  class="oe_highlight"  />
@@ -47,6 +48,20 @@
                 <field name="quantity_onstock" sum="# of Products Available"/>
                 <field name="inventory_value" invisible="1" sum="Total Value"/>
             </tree>
+            </field>
+        </record>
+
+        <record id="view_stock_demand_history_search" model="ir.ui.view">
+            <field name="name">Stock History Search</field>
+            <field name="model">stock.history</field>
+            <field name="inherit_id" ref="stock_account.view_stock_history_report_search"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='location_id']" position="after">
+                    <field name="quantity" string="Demand Lines" context="{}" filter_domain="[('quantity', '&lt;', 0.0)]"/>
+                    <field name="date"/>
+                    <field name="date" string="Date From" context="{}" filter_domain="[('date', '&gt;=', self)]"/>
+                    <field name="date" string="Date To" context="{}" filter_domain="[('date', '&lt;=', self)]"/>
+                </xpath>
             </field>
         </record>
 


### PR DESCRIPTION
# HU#913 Sprint 21

This PR was made trying to find the way to add the date range domain and pre load then in the `stock.history` view generate via the `stock.demand` wizard. This to make easy the user to generate a Stock Demand Forecast Rule after running the Stock Demand wizard.

The initial approach do not work so a new and better approach was made. Stock Demand wizard add a new boolean field that let the user to select if want to automatically create the ir filter to use for forecast rule. This is better because all the other data like the forecast context extra required values and some others are already added to the filter This way the user only need to run the stock demand wizard and then select the filter in the forecast rule.

This PR Close #66 

## TODO
- [x] review with nhomar the PR with the new Generate Filter boolean and the change to only extract demand for date instead datetime.
- [x] update module description with the new functionality
- [x] update module translations
- [x] update test to resolve coverage red
- [x] make squash 