### PR TITLE
[FIX] update stock_forecast module to make it compatible with yoytec_customer_rma_workflow module.

### DIFF
--- a/stock_forecast/demo/product_product.xml
+++ b/stock_forecast/demo/product_product.xml
@@ -7,8 +7,8 @@
             <record id="product_product_1" model="product.product">
                 <field name="name">iMac with Retina 5K display</field>
                 <field name="categ_id" ref="product.imac"/>
-                <field name="standard_price">1499.0</field>
-                <field name="list_price">1899.0</field>
+                <field name="standard_price">3499.0</field>
+                <field name="list_price">3899.0</field>
                 <field name="type">consu</field>
                 <field name="uom_id" ref="product.product_uom_unit"/>
                 <field name="uom_po_id" ref="product.product_uom_unit"/>


### PR DESCRIPTION
This POC was originated by from Vauxoo/yoytec#473

When the `stock_forecast` module integrate with the `yoytec_customer_rma_workflow` module in a same instance a [problem](https://travis-ci.com/Vauxoo/yoytec/jobs/29197131#L1674) occurs. To try to fix it, we will change the price of the computers products defined in the `stock_forecast` module.
