### PR TITLE
[IMP] manage dependecies via oca_dependencies.txt file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,6 @@ install:
   - pip install -r ${TRAVIS_BUILD_DIR}/requirements.txt
   - git clone --single-branch --depth=1 https://github.com/vauxoo/maintainer-quality-tools.git -b master ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
-  - git clone --single-branch --depth=1 https://github.com/Vauxoo/web.git -b ${VERSION} ${HOME}/web
-  - git clone --single-branch --depth=1 https://github.com/Vauxoo/addons-vauxoo.git -b ${VERSION} ${HOME}/addons-vauxoo
   - travis_install_nightly
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ env:
   - VERSION="8.0" ODOO_REPO="vauxoo/odoo" TESTS=1 LINT_CHECK=0 ODOO_LINT=0
 
 install:
-  - pip install -r ${TRAVIS_BUILD_DIR}/requirements.txt
   - git clone --single-branch --depth=1 https://github.com/vauxoo/maintainer-quality-tools.git -b master ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,0 +1,2 @@
+web https://github.com/Vauxoo/web.git
+addons-vauxooo https://github.com/Vauxoo/addons-vauxoo.git


### PR DESCRIPTION
in travis there is a git clone for `vauxoo/web` and `vauxoo/addons-vauxoo`. This should be remove and need to be added as `oca_dependencies.txt`.