### PR TITLE
[8.0][forecasting_smoothing_techniques] Added improvement in the compute process 

### DIFF
--- a/forecasting_rules/models/ir_filters.py
+++ b/forecasting_rules/models/ir_filters.py
@@ -154,7 +154,7 @@ class IrFilters(models.Model):
         data = pd.DataFrame(values)
 
         # Order by date
-        if len(data):
+        if not data.empty:
             data[order] = pd.to_datetime(data[order])
             data = data.set_index(order)
 


### PR DESCRIPTION
[IMP] Added an index over forecast_id field in forecast_data table. This was added to improve the speed at the moment to get the lines used to compute the corresponding values for each computed field in forecast model

[IMP] The method used to compute wma values was separated in two parts. The first one is used to only compute the needed values, this is useful when you only want to know the value for an specific forcast without wasting time in write methods. The second one only get the values and write them in the corresponding forecast, to show the values in the forecast when the view is open